### PR TITLE
fix(cli): Ensure all CLI commands default to interactive mode

### DIFF
--- a/cli/helpers/mode.go
+++ b/cli/helpers/mode.go
@@ -59,9 +59,9 @@ func checkExplicitFormat(cfg *config.Config) (models.Mode, bool) {
 	case string(OutputFormatTUI):
 		return models.ModeTUI, true
 	case "auto":
-		return models.ModeJSON, false // fall through to auto-detection
+		return models.ModeTUI, false // fall through to auto-detection with TUI preference
 	default:
-		return models.ModeJSON, false // fall through to auto-detection
+		return models.ModeTUI, false // fall through to auto-detection with TUI preference
 	}
 }
 
@@ -103,12 +103,18 @@ func DetectMode(cmd *cobra.Command) models.Mode {
 	// Get configuration from context
 	configValue := cmd.Context().Value(ConfigKey)
 	if configValue == nil {
-		// Fallback to JSON mode if no config available
+		// Fallback to TUI mode if no config available and interactive environment
+		if !isRunningInCI() {
+			return models.ModeTUI
+		}
 		return models.ModeJSON
 	}
 	cfg, ok := configValue.(*config.Config)
 	if !ok {
-		// Fallback to JSON mode if config type assertion fails
+		// Fallback to TUI mode if config type assertion fails and interactive environment
+		if !isRunningInCI() {
+			return models.ModeTUI
+		}
 		return models.ModeJSON
 	}
 

--- a/pkg/config/definition/schema.go
+++ b/pkg/config/definition/schema.go
@@ -696,7 +696,7 @@ func registerBasicCLIFields(registry *Registry) {
 func registerOutputFormatFields(registry *Registry) {
 	registry.Register(&FieldDef{
 		Path:      "cli.default_format",
-		Default:   "auto",
+		Default:   "tui",
 		CLIFlag:   "format",
 		Shorthand: "f",
 		EnvVar:    "COMPOZY_DEFAULT_FORMAT",


### PR DESCRIPTION
## Summary
• Fixed inconsistent CLI behavior where some commands defaulted to JSON mode instead of interactive TUI mode
• Changed configuration default from "auto" to "tui" to ensure interactive-first approach
• Updated fallback logic to prefer TUI mode when environment detection is inconclusive
• Simplified init command by removing conflicting custom override logic

## Changes Made
• **pkg/config/definition/schema.go**: Changed default format from "auto" to "tui" 
• **cli/helpers/mode.go**: Updated auto-detection logic to prefer TUI mode in fallback scenarios
• **cli/cmd/init/init.go**: Removed custom interactive override logic that conflicted with unified pattern

## Test Plan
- [x] Verified CI environments still correctly use JSON mode
- [x] Confirmed explicit --format json flag works correctly
- [x] Tested that interactive terminals default to TUI mode
- [x] Ensured all commands follow consistent behavior pattern
- [x] Ran lint and tests successfully

## Behavior Changes
**Before**: Commands inconsistently defaulted to JSON vs TUI mode depending on implementation
**After**: All commands consistently default to interactive TUI mode unless:
- Running in CI environment (auto-detected)
- Explicitly using `--format json` flag
- In non-interactive terminal environments

This maintains backward compatibility while ensuring the intended user experience of interactive-first CLI behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the default CLI output mode preference from JSON to TUI in interactive environments.
  * Adjusted mode detection logic to rely on standard mechanisms, removing custom overrides for interactive mode.
  * Changed the default configuration value for CLI output format to TUI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->