### PR TITLE
fix(repo): Response handler for attachments

### DIFF
--- a/engine/llm/adapter/interface.go
+++ b/engine/llm/adapter/interface.go
@@ -121,6 +121,8 @@ type CallOptions struct {
 	StopWords    []string
 	ToolChoice   string // "auto", "none", or specific tool name
 	OutputFormat OutputFormat
+	ForceJSON    bool
+	ResponseMIME string
 }
 
 // LLMResponse represents the response from the LLM

--- a/engine/llm/adapter/langchain_adapter.go
+++ b/engine/llm/adapter/langchain_adapter.go
@@ -318,6 +318,14 @@ func (a *LangChainAdapter) buildCallOptions(req *LLMRequest) []llms.CallOption {
 		options = append(options, llms.WithTools(tools))
 	}
 
+	if req.Options.ForceJSON {
+		options = append(options, llms.WithJSONMode())
+	}
+
+	if req.Options.ResponseMIME != "" {
+		options = append(options, llms.WithResponseMIMEType(req.Options.ResponseMIME))
+	}
+
 	// Set tool choice directive when provided (including "none")
 	if req.Options.ToolChoice != "" {
 		options = append(options, llms.WithToolChoice(req.Options.ToolChoice))

--- a/engine/llm/orchestrator/request_builder.go
+++ b/engine/llm/orchestrator/request_builder.go
@@ -59,8 +59,7 @@ func (b *requestBuilder) Build(
 		toolChoice = "auto"
 	}
 
-	forceJSON := b.computeJSONPreferences(promptData.format, request)
-
+	forceJSON := b.computeJSONPreferences(ctx, promptData.format, request)
 	logger.FromContext(ctx).Debug("LLM request prepared",
 		"agent_id", request.Agent.ID,
 		"action_id", request.Action.ID,
@@ -86,10 +85,15 @@ func (b *requestBuilder) Build(
 	}, nil
 }
 
+// computeJSONPreferences determines whether to request forced JSON output based on
+// the action schema, desired output format, and provider capabilities. It returns
+// true when the provider requires explicit JSON mode to honor the schema.
 func (b *requestBuilder) computeJSONPreferences(
+	ctx context.Context,
 	format llmadapter.OutputFormat,
 	request Request,
 ) bool {
+	_ = ctx
 	action := request.Action
 	if action == nil || action.OutputSchema == nil {
 		return false

--- a/engine/llm/orchestrator/request_builder_helpers_test.go
+++ b/engine/llm/orchestrator/request_builder_helpers_test.go
@@ -161,18 +161,19 @@ func TestRequestBuilder_ComputeJSONPreferences(t *testing.T) {
 		Action: action,
 	}
 
-	force := rb.computeJSONPreferences(llmadapter.DefaultOutputFormat(), request)
+	ctx := context.Background()
+	force := rb.computeJSONPreferences(ctx, llmadapter.DefaultOutputFormat(), request)
 	assert.False(t, force)
 
 	request.Agent.Model.Config.Provider = core.ProviderOpenAI
-	force = rb.computeJSONPreferences(llmadapter.DefaultOutputFormat(), request)
+	force = rb.computeJSONPreferences(ctx, llmadapter.DefaultOutputFormat(), request)
 	assert.True(t, force)
 
 	format := llmadapter.NewJSONSchemaOutputFormat("structured", schemaObj, true)
-	force = rb.computeJSONPreferences(format, request)
+	force = rb.computeJSONPreferences(ctx, format, request)
 	assert.False(t, force)
 
 	request.Action = nil
-	force = rb.computeJSONPreferences(llmadapter.DefaultOutputFormat(), request)
+	force = rb.computeJSONPreferences(ctx, llmadapter.DefaultOutputFormat(), request)
 	assert.False(t, force)
 }

--- a/engine/llm/orchestrator/request_builder_helpers_test.go
+++ b/engine/llm/orchestrator/request_builder_helpers_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/compozy/compozy/engine/agent"
+	"github.com/compozy/compozy/engine/core"
 	llmadapter "github.com/compozy/compozy/engine/llm/adapter"
 	"github.com/compozy/compozy/engine/schema"
 	"github.com/compozy/compozy/engine/tool"
@@ -148,4 +150,29 @@ func TestNormalizeToolParameters_PreservesProvidedSchemaFields(t *testing.T) {
 	require.True(t, ok)
 	_, has := props["foo"]
 	assert.True(t, has)
+}
+
+func TestRequestBuilder_ComputeJSONPreferences(t *testing.T) {
+	rb := &requestBuilder{}
+	schemaObj := &schema.Schema{"type": "object"}
+	action := &agent.ActionConfig{ID: "structured", OutputSchema: schemaObj}
+	request := Request{
+		Agent:  &agent.Config{Model: agent.Model{Config: core.ProviderConfig{Provider: core.ProviderGoogle}}},
+		Action: action,
+	}
+
+	force := rb.computeJSONPreferences(llmadapter.DefaultOutputFormat(), request)
+	assert.False(t, force)
+
+	request.Agent.Model.Config.Provider = core.ProviderOpenAI
+	force = rb.computeJSONPreferences(llmadapter.DefaultOutputFormat(), request)
+	assert.True(t, force)
+
+	format := llmadapter.NewJSONSchemaOutputFormat("structured", schemaObj, true)
+	force = rb.computeJSONPreferences(format, request)
+	assert.False(t, force)
+
+	request.Action = nil
+	force = rb.computeJSONPreferences(llmadapter.DefaultOutputFormat(), request)
+	assert.False(t, force)
 }

--- a/engine/llm/orchestrator/response_handler_test.go
+++ b/engine/llm/orchestrator/response_handler_test.go
@@ -97,6 +97,14 @@ func TestResponseHandler_ParseContent(t *testing.T) {
 		assert.Equal(t, ErrCodeInvalidResponse, coreErr.Code)
 		require.ErrorContains(t, err, "expected structured JSON output")
 	})
+	t.Run("Should extract embedded JSON when schema required", func(t *testing.T) {
+		action := &agent.ActionConfig{OutputSchema: &schema.Schema{"type": "object"}}
+		content := `Sure! Here is the result:\n\n{"pokemon":"Pikachu","confidence":0.82}`
+		output, err := h.(*responseHandler).parseContent(context.Background(), content, action)
+		require.NoError(t, err)
+		require.NotNil(t, output)
+		assert.Equal(t, "Pikachu", (*output)["pokemon"])
+	})
 }
 
 func TestResponseHandler_ContentErrorExtraction(t *testing.T) {
@@ -146,5 +154,25 @@ func TestResponseHandler_ContentErrorExtraction(t *testing.T) {
 		assert.Equal(t, ErrCodeBudgetExceeded, coreErr.Code)
 		require.NotNil(t, coreErr.Details)
 		assert.Equal(t, "bad", coreErr.Details["details"])
+	})
+}
+
+func TestExtractJSONObject(t *testing.T) {
+	t.Run("Should return first balanced object", func(t *testing.T) {
+		jsonText := "prefix {\"a\":1,\"b\":{\"c\":2}} suffix"
+		snippet, ok := extractJSONObject(jsonText)
+		require.True(t, ok)
+		assert.Equal(t, "{\"a\":1,\"b\":{\"c\":2}}", snippet)
+	})
+	t.Run("Should ignore braces inside strings", func(t *testing.T) {
+		jsonText := "text {\"a\":\"{nested}\"} tail"
+		snippet, ok := extractJSONObject(jsonText)
+		require.True(t, ok)
+		assert.Equal(t, "{\"a\":\"{nested}\"}", snippet)
+	})
+	t.Run("Should return false when missing object", func(t *testing.T) {
+		snippet, ok := extractJSONObject("no json here")
+		require.False(t, ok)
+		assert.Empty(t, snippet)
 	})
 }

--- a/examples/pokemon/workflow.yaml
+++ b/examples/pokemon/workflow.yaml
@@ -24,7 +24,7 @@ config:
 
 agents:
   - id: image_analyzer
-    config:
+    model:
       provider: openai
       model: gpt-4o-mini
       api_key: "{{ .env.OPENAI_API_KEY }}"
@@ -46,7 +46,7 @@ agents:
             - confidence
 
   - id: media_analyzer
-    config:
+    model:
       provider: google
       model: gemini-2.5-flash
       api_key: "{{ .env.GOOGLE_API_KEY }}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Add options to force JSON output and to specify a response MIME type for model calls.
  - Automatic logic determines when to enable JSON mode based on provider, action schema, and requested output format.
  - Improved response handling extracts and validates embedded/top-level JSON found inside plain-text model outputs when structured data is expected.

- Tests
  - Added tests covering JSON-mode selection across providers and formats.
  - Added tests for extracting the first balanced JSON object, handling braces in string literals, and absence cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->