### PR TITLE
fix(task): Evaluate timeout templates in wait tasks before execution

### DIFF
--- a/engine/task/activities/exec_wait.go
+++ b/engine/task/activities/exec_wait.go
@@ -136,6 +136,8 @@ func validateWaitConfig(cfg *task.Config) error {
 }
 
 // parseTimeout parses and validates the timeout from the normalized configuration.
+// It converts the human-readable timeout string (e.g., "5m", "2h30m") to a time.Duration
+// and ensures it is positive. Returns an error if the timeout is missing, invalid, or non-positive.
 func parseTimeout(cfg *task.Config) (time.Duration, error) {
 	if cfg.Timeout == "" {
 		return 0, fmt.Errorf("wait task requires a timeout")
@@ -151,6 +153,7 @@ func parseTimeout(cfg *task.Config) (time.Duration, error) {
 }
 
 // createWaitTaskState creates and augments the state for the wait task.
+// It stores the parsed timeout in both seconds and milliseconds for flexible consumption.
 func (a *ExecuteWait) createWaitTaskState(
 	ctx context.Context,
 	workflowState *workflow.State,
@@ -168,10 +171,11 @@ func (a *ExecuteWait) createWaitTaskState(
 	}
 	taskState.Status = core.StatusWaiting
 	taskState.Output = &core.Output{
-		"wait_status":     "waiting",
-		"signal_name":     cfg.WaitFor,
-		"has_processor":   cfg.Processor != nil,
-		"timeout_seconds": int64(timeout.Seconds()),
+		"wait_status":          "waiting",
+		"signal_name":          cfg.WaitFor,
+		"has_processor":        cfg.Processor != nil,
+		"timeout_seconds":      int64(timeout.Seconds()),
+		"timeout_milliseconds": timeout.Milliseconds(),
 	}
 	return taskState, nil
 }

--- a/engine/task/activities/exec_wait.go
+++ b/engine/task/activities/exec_wait.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/compozy/compozy/engine/core"
 	"github.com/compozy/compozy/engine/task"
@@ -63,7 +64,11 @@ func (a *ExecuteWait) Run(ctx context.Context, input *ExecuteWaitInput) (*task.M
 	if err := validateWaitConfig(normalizedConfig); err != nil {
 		return nil, err
 	}
-	taskState, err := a.createWaitTaskState(ctx, workflowState, workflowConfig, normalizedConfig)
+	timeout, err := parseTimeout(normalizedConfig)
+	if err != nil {
+		return nil, err
+	}
+	taskState, err := a.createWaitTaskState(ctx, workflowState, workflowConfig, normalizedConfig, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -130,12 +135,28 @@ func validateWaitConfig(cfg *task.Config) error {
 	return nil
 }
 
+// parseTimeout parses and validates the timeout from the normalized configuration.
+func parseTimeout(cfg *task.Config) (time.Duration, error) {
+	if cfg.Timeout == "" {
+		return 0, fmt.Errorf("wait task requires a timeout")
+	}
+	timeout, err := core.ParseHumanDuration(cfg.Timeout)
+	if err != nil {
+		return 0, fmt.Errorf("invalid timeout format: %w", err)
+	}
+	if timeout <= 0 {
+		return 0, fmt.Errorf("wait task requires a positive timeout (got %s)", cfg.Timeout)
+	}
+	return timeout, nil
+}
+
 // createWaitTaskState creates and augments the state for the wait task.
 func (a *ExecuteWait) createWaitTaskState(
 	ctx context.Context,
 	workflowState *workflow.State,
 	workflowConfig *workflow.Config,
 	cfg *task.Config,
+	timeout time.Duration,
 ) (*task.State, error) {
 	taskState, err := a.createStateUC.Execute(ctx, &uc.CreateStateInput{
 		WorkflowState:  workflowState,
@@ -147,9 +168,10 @@ func (a *ExecuteWait) createWaitTaskState(
 	}
 	taskState.Status = core.StatusWaiting
 	taskState.Output = &core.Output{
-		"wait_status":   "waiting",
-		"signal_name":   cfg.WaitFor,
-		"has_processor": cfg.Processor != nil,
+		"wait_status":     "waiting",
+		"signal_name":     cfg.WaitFor,
+		"has_processor":   cfg.Processor != nil,
+		"timeout_seconds": int64(timeout.Seconds()),
 	}
 	return taskState, nil
 }

--- a/engine/task/activities/exec_wait_test.go
+++ b/engine/task/activities/exec_wait_test.go
@@ -118,6 +118,7 @@ func TestExecuteWait_Run(t *testing.T) {
 		assert.Equal(t, "approval_signal", output["signal_name"])
 		assert.Equal(t, false, output["has_processor"])
 		assert.Equal(t, int64(300), output["timeout_seconds"], "Should contain timeout in seconds (5m = 300s)")
+		assert.Equal(t, int64(300000), output["timeout_milliseconds"], "Should contain timeout in ms (5m = 300000ms)")
 
 		// Verify state was saved to database
 		savedState, err := taskRepo.GetState(ctx, response.State.TaskExecID)
@@ -234,6 +235,12 @@ func TestExecuteWait_Run(t *testing.T) {
 			int64(7500),
 			waitOutput["timeout_seconds"],
 			"Should contain parsed timeout in seconds (2h5m = 7500s)",
+		)
+		assert.Equal(
+			t,
+			int64(7500000),
+			waitOutput["timeout_milliseconds"],
+			"Should contain parsed timeout in ms (2h5m = 7500000ms)",
 		)
 	})
 	t.Run("Should handle nil task config", func(t *testing.T) {
@@ -536,6 +543,8 @@ func TestExecuteWait_Run(t *testing.T) {
 		// Verify has_processor is true
 		output := *response.State.Output
 		assert.Equal(t, true, output["has_processor"])
+		assert.Equal(t, int64(600), output["timeout_seconds"], "Should contain timeout in seconds (10m = 600s)")
+		assert.Equal(t, int64(600000), output["timeout_milliseconds"], "Should contain timeout in ms (10m = 600000ms)")
 
 		// Verify state was saved to database with has_processor = true
 		savedState, err := taskRepo.GetState(ctx, response.State.TaskExecID)

--- a/engine/task/activities/exec_wait_test.go
+++ b/engine/task/activities/exec_wait_test.go
@@ -42,6 +42,7 @@ func TestExecuteWait_Run(t *testing.T) {
 						ID:        "wait-task",
 						Type:      task.TaskTypeWait,
 						Condition: `signal.payload.approved == true`,
+						Timeout:   "5m",
 					},
 					WaitTask: task.WaitTask{
 						WaitFor: "approval_signal",
@@ -65,6 +66,7 @@ func TestExecuteWait_Run(t *testing.T) {
 				ID:        "wait-task",
 				Type:      task.TaskTypeWait,
 				Condition: `signal.payload.approved == true`,
+				Timeout:   "5m",
 			},
 			WaitTask: task.WaitTask{
 				WaitFor: "approval_signal",
@@ -115,6 +117,7 @@ func TestExecuteWait_Run(t *testing.T) {
 		assert.Equal(t, "waiting", output["wait_status"])
 		assert.Equal(t, "approval_signal", output["signal_name"])
 		assert.Equal(t, false, output["has_processor"])
+		assert.Equal(t, int64(300), output["timeout_seconds"], "Should contain timeout in seconds (5m = 300s)")
 
 		// Verify state was saved to database
 		savedState, err := taskRepo.GetState(ctx, response.State.TaskExecID)
@@ -226,6 +229,12 @@ func TestExecuteWait_Run(t *testing.T) {
 		assert.NotNil(t, response.State.Output)
 		waitOutput := *response.State.Output
 		assert.Equal(t, "reminder-signal", waitOutput["signal_name"])
+		assert.Equal(
+			t,
+			int64(7500),
+			waitOutput["timeout_seconds"],
+			"Should contain parsed timeout in seconds (2h5m = 7500s)",
+		)
 	})
 	t.Run("Should handle nil task config", func(t *testing.T) {
 		// Arrange
@@ -444,6 +453,7 @@ func TestExecuteWait_Run(t *testing.T) {
 						ID:        "wait-task",
 						Type:      task.TaskTypeWait,
 						Condition: `processor.output.valid == true`,
+						Timeout:   "10m",
 					},
 					WaitTask: task.WaitTask{
 						WaitFor: "data_signal",
@@ -473,6 +483,7 @@ func TestExecuteWait_Run(t *testing.T) {
 				ID:        "wait-task",
 				Type:      task.TaskTypeWait,
 				Condition: `processor.output.valid == true`,
+				Timeout:   "10m",
 			},
 			WaitTask: task.WaitTask{
 				WaitFor: "data_signal",

--- a/engine/worker/executors/task_wait.go
+++ b/engine/worker/executors/task_wait.go
@@ -147,6 +147,10 @@ type WaitState struct {
 	Error           error
 }
 
+// extractTimeout retrieves the parsed timeout duration from the activity response output.
+// It reads timeout_seconds from the response (set by the activity after template evaluation)
+// and converts it to time.Duration. Handles both int64 and float64 types for JSON compatibility.
+// Returns an error if the response is invalid, timeout is missing, or has an invalid value.
 func (e *TaskWaitExecutor) extractTimeout(response *task.MainTaskResponse) (time.Duration, error) {
 	if response == nil || response.State == nil || response.State.Output == nil {
 		return 0, fmt.Errorf("response state or output is nil")
@@ -253,6 +257,8 @@ func (e *TaskWaitExecutor) handleTimeoutResponse(
 		map[string]any{
 			"signal_name": taskConfig.WaitFor,
 			"timeout":     taskConfig.Timeout,
+			"timeout_ms":  timeout.Milliseconds(),
+			"timeout_sec": int64(timeout.Seconds()),
 		},
 	)
 	if taskConfig.OnTimeout != "" {


### PR DESCRIPTION
## Summary
Fixes the issue where timeout fields with template expressions were not being evaluated in wait tasks, causing `ParseHumanDuration()` to receive literal template strings instead of evaluated values (e.g., `"{{ default .workflow.input.timeout_duration .tasks.calculate_delay.output.duration }}"` instead of `"1m58s"`).

## Root Cause Analysis
The timeout template evaluation failed due to an architectural timing issue with Temporal workflows:

1. **Task config normalization** (where templates are evaluated) happens **inside the ExecuteWait activity**
2. The **workflow executor** operates in a **deterministic Temporal context** where activities cannot modify workflow variables
3. The workflow's `taskConfig` variable remained **unchanged** after the activity returned
4. When `validateTimeout()` was called, it parsed the **literal template string** because it was working with the original, non-normalized config

## Solution
Instead of validating the timeout in the workflow context (where the normalized config is inaccessible), the fix:

1. **Parses and validates the timeout INSIDE the activity** after normalization
2. **Stores the parsed timeout** (in seconds) in the activity response output as `timeout_seconds`
3. **Extracts the timeout from the response** in the workflow executor instead of parsing the config
4. **Handles type flexibility** for JSON compatibility (both int64 and float64)

## Changes

### `engine/task/activities/exec_wait.go`
- Added `parseTimeout()` function to parse and validate timeout after normalization
- Modified `createWaitTaskState()` to accept parsed timeout and store `timeout_seconds` in output
- Updated `Run()` to call `parseTimeout()` and pass result to `createWaitTaskState()`

### `engine/worker/executors/task_wait.go`
- Replaced `validateTimeout()` with `extractTimeout()` that reads from activity response
- `extractTimeout()` extracts `timeout_seconds` from response output
- Handles both int64 and float64 types for JSON marshaling/unmarshaling

### Tests
- Added `timeout_seconds` assertions to existing tests in `exec_wait_test.go`
- Updated all wait task test configs to include timeout field
- Created comprehensive `TestTaskWaitExecutor_ExtractTimeout()` with 9 test cases covering:
  - Successful extraction with int64 and float64 types
  - Error cases (nil response/state/output, missing field, wrong type, zero/negative timeouts)

## Testing
All tests pass:
```
✓ engine/worker/executors (17 tests)
✓ engine/task/activities (17 tests)
✓ golangci-lint: 0 issues
```

## Example Usage
With this fix, reminder workflows using templated timeouts now work correctly:

```yaml
tasks:
  - id: calculate_delay
    type: basic
    tool: calculate_reminder_delay
    on_success:
      next: wait_for_fire_time
  
  - id: wait_for_fire_time
    type: wait
    wait_for: "cancel-reminder-{{ .workflow.input.reminder_id }}"
    timeout: "{{ default .workflow.input.timeout_duration .tasks.calculate_delay.output.duration }}"
    condition: 'has(signal.payload.command) && signal.payload.command == "cancel"'
    on_timeout: fire_reminder
```

The timeout template will be properly evaluated to the duration calculated by the first task.

## Related Issues
Addresses timeout template evaluation failures in wait tasks where user-provided durations or calculated timeouts were not being resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wait tasks now accept validated configurable timeouts; parsed values are included in task outputs as seconds and milliseconds.

* **Refactor**
  * Timeout handling moved to rely on task outputs for extraction; execution flow updated to extract timeouts from responses and surface timeout_ms/timeout_sec in error metadata. Old config-based parsing removed.

* **Tests**
  * Added extensive tests for timeout parsing, propagation, extraction and error cases (numeric, templated, missing/invalid/negative).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->